### PR TITLE
Use or emulate pwdx instead of /proc

### DIFF
--- a/zranger
+++ b/zranger
@@ -17,8 +17,15 @@ else
     TMUX='' tmux new-session -s ranger 'exec ranger --cmd="set preview_images=false"'
 fi
 
+# Emulate pwdx if not available
+if ! type pwdx >/dev/null; then
+  function pwdx {
+    lsof -a -d cwd -p $1 -n -Fn | awk '/^n/ {print substr($0,2)}'
+  }
+fi
+
 # A second check needed because the process could have been
 # started or stopped in the meantime.
 if RANGER_PID=$(tmux list-panes -s -F '#{pane_pid}' -t ranger 2> /dev/null); then
-    cd -P /proc/$RANGER_PID/cwd
+    cd -P "$(pwdx $RANGER_PID)"
 fi


### PR DESCRIPTION
Fixes to work on Mac OS X by replacing usage of the /proc filesystem with pwdx (emulating if necessary).

This fixes Issue #2.